### PR TITLE
adding different stages for config setup

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -6,10 +6,14 @@ import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import play.api.{ApplicationLoader, Mode}
 
-class Config(context: ApplicationLoader.Context) {
+class Config(context: ApplicationLoader.Context) extends {
   val isDev: Boolean = context.environment.mode == Mode.Dev
   lazy val no2faUser: String = "composer.test@guardian.co.uk"
-  lazy val domain: String = "local.dev-gutools.co.uk"
+  lazy val domain: String = stage match {
+    case "PROD" => s"gutools.co.,uk"
+    case "CODE" => s"code.dev-gutools.co.uk"
+    case _ => s"local.dev-gutools.co.uk"
+  }
   lazy val host: String = s"https://atom-preview.$domain"
   lazy val pandaSystem: String = "atom-preview"
   lazy val pandaBucketName: String = "pan-domain-auth-settings"

--- a/nginx-mapping.yaml
+++ b/nginx-mapping.yaml
@@ -1,4 +1,4 @@
-name: atom-preview
+devname: atom-preview
 mappings:
   - prefix: atom-preview
     port: 9000


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
A PR to allow for the app to be deployed to a variety of stages (Local, CODE and PROD)depending on the initiated call to setup in Config
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
