### PR TITLE
add node setup to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16.13.0'
+          node-version-file: '.nvmrc'
 
       - name: Setup Java 8
         uses: actions/setup-java@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.13.0'
+
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
A simple PR, does what it says on the tin: adds a node setup to the project as part of CI.
- Using actions/setup-node@v2 GitHub Action, which sets up the Node.js environment for the subsequent steps in the CI workflow. It specifies the Node.js version 16.13.0 to be installed.
- Using the actions/setup-java@v2 GitHub Action, which sets up the Java environment for the subsequent steps in the CI workflow.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
